### PR TITLE
Improve skin imagery and add themed case content

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,15 @@ const rarityConfig = {
     legendary: { label: 'Exceedingly Rare', className: 'rarity-legendary', labelClass: 'rarity-label-legendary', weight: 0.1 }
 };
 
+const categoryLabels = {
+    featured: 'Топ выбор',
+    premium: 'Премиум',
+    awp: 'AWP',
+    pistol: 'Пистолеты',
+    farm: 'Фарм',
+    budget: 'Бюджет'
+};
+
 const IMAGE_BASE_URL = 'https://steamcommunity.com/economy/image/item/730/';
 const FALLBACK_IMAGE = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyMDAgMjAwJz48cmVjdCB3aWR0aD0nMjAwJyBoZWlnaHQ9JzIwMCcgZmlsbD0nIzExMTgyNycvPjx0ZXh0IHg9JzUwJScgeT0nNTAlJyBmaWxsPScjOWNhM2FmJyBmb250LWZhbWlseT0nUm9ib3RvLEFyaWFsLHNhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMjQnIHRleHQtYW5jaG9yPSdtaWRkbGUnIGRvbWluYW50LWJhc2VsaW5lPSdtaWRkbGUnPk5PIElNQUdFPC90ZXh0Pjwvc3ZnPg==';
 
@@ -47,6 +56,7 @@ const rawCases = [
         id: 'phoenix-pro',
         name: 'Пламя Феникса',
         price: 6.49,
+        category: 'featured',
         description: 'Сбалансированный набор ярких AR и AWP скинов с шансом на редчайшие дропы.',
         showcase: [
             { name: 'AK-47 | Asiimov', wear: 'Field-Tested' },
@@ -72,6 +82,7 @@ const rawCases = [
         id: 'night-operation',
         name: 'Ночная операция',
         price: 9.99,
+        category: 'premium',
         description: 'Всё для тактических ночных рейдов — темные и дорогие скины с шансом на нож.',
         showcase: [
             { name: 'M4A1-S | Printstream', wear: 'Field-Tested' },
@@ -99,6 +110,7 @@ const rawCases = [
         id: 'ancient-treasures',
         name: 'Древние сокровища',
         price: 3.99,
+        category: 'featured',
         description: 'Доступный кейс с фокусом на окупаемость за счёт редких предметов из древних коллекций.',
         showcase: [
             { name: 'AK-47 | Legion of Anubis', wear: 'Field-Tested' },
@@ -124,6 +136,7 @@ const rawCases = [
         id: 'budget-rush',
         name: 'Бюджетный прорыв',
         price: 1.89,
+        category: 'budget',
         description: 'Идеальный кейс для старта — много дешёвых дропов и шанс на редкие апгрейды.',
         showcase: [
             { name: 'AK-47 | Slate', wear: 'Field-Tested' },
@@ -149,6 +162,7 @@ const rawCases = [
         id: 'knife-express',
         name: 'Ножевой экспресс',
         price: 49.99,
+        category: 'premium',
         description: 'Максимальные шансы на ножи и топовые covert-предметы. Лучшее для хайроллеров.',
         showcase: [
             { name: '★ Karambit | Gamma Doppler', wear: 'Factory New' },
@@ -174,6 +188,7 @@ const rawCases = [
         id: 'awp-sanctum',
         name: 'AWP: Святилище',
         price: 12.49,
+        category: 'awp',
         description: 'Коллекция из культовых AWP — от легендарного Dragon Lore до бюджетного Mortis.',
         showcase: [
             { name: 'AWP | Dragon Lore', wear: 'Factory New' },
@@ -199,6 +214,7 @@ const rawCases = [
         id: 'deagle-syndicate',
         name: 'Синдикат Deagle',
         price: 7.79,
+        category: 'pistol',
         description: 'Только Desert Eagle — от легендарного Blaze до доступного Oxide Blaze.',
         showcase: [
             { name: 'Desert Eagle | Blaze', wear: 'Factory New' },
@@ -226,6 +242,7 @@ const rawCases = [
         id: 'usp-blacksite',
         name: 'Черный сектор USP',
         price: 5.89,
+        category: 'pistol',
         description: 'Коллекция для ценителей USP-S: редкие неонуары и бюджетные варианты.',
         showcase: [
             { name: 'USP-S | Kill Confirmed', wear: 'Field-Tested' },
@@ -253,6 +270,7 @@ const rawCases = [
         id: 'farm-gold',
         name: 'Фарм кейс: Золотая охота',
         price: 2.59,
+        category: 'farm',
         description: 'Один шанс на золотой нож и гора ширпа для фарма контрактов.',
         showcase: [
             { name: '★ Butterfly Knife | Lore', wear: 'Field-Tested' },
@@ -273,6 +291,7 @@ const rawCases = [
         id: 'farm-emerald',
         name: 'Фарм кейс: Изумрудный миф',
         price: 3.19,
+        category: 'farm',
         description: 'Мизерный шанс на изумрудный карамбит и куча дешёвых пушек для апгрейдов.',
         showcase: [
             { name: '★ Karambit | Gamma Doppler', wear: 'Factory New' },
@@ -325,11 +344,19 @@ const selectors = {
     closeModal: document.getElementById('closeModal'),
     depositBtn: document.getElementById('depositBtn'),
     heroDeposit: document.getElementById('heroDeposit'),
+    depositModal: document.getElementById('depositModal'),
+    depositForm: document.getElementById('depositForm'),
+    depositAmount: document.getElementById('depositAmount'),
+    depositError: document.getElementById('depositError'),
+    closeDeposit: document.getElementById('closeDeposit'),
+    depositCancel: document.getElementById('depositCancel'),
+    filterButtons: Array.from(document.querySelectorAll('.case-filters [data-filter]')),
 };
 
 let currentBalance = Number(localStorage.getItem('cs2-case-balance')) || 150.00;
 let inventory = JSON.parse(localStorage.getItem('cs2-case-inventory') || '[]');
 let legacyInventoryMigrated = false;
+let activeFilter = 'all';
 inventory = inventory.map((item) => {
     const fullName = item.fullName || (item.wear ? `${item.name} (${item.wear})` : item.name);
     const needsImageRefresh = !item.image || /csgostash|skin_sideview/.test(item.image);
@@ -358,6 +385,20 @@ function saveState() {
     localStorage.setItem('cs2-case-inventory', JSON.stringify(inventory));
 }
 
+function isHidden(element) {
+    return !element || element.classList.contains('hidden');
+}
+
+function showOverlay() {
+    selectors.overlay.classList.remove('hidden');
+}
+
+function hideOverlayIfIdle() {
+    if (isHidden(selectors.caseModal) && isHidden(selectors.depositModal)) {
+        selectors.overlay.classList.add('hidden');
+    }
+}
+
 function updateBalanceDisplay() {
     selectors.balance.textContent = formatCurrency(currentBalance);
 }
@@ -371,10 +412,20 @@ function updateInventorySummary() {
 function createCaseCard(caseData) {
     const card = document.createElement('article');
     card.className = 'case-card';
+    card.dataset.category = caseData.category;
 
     const header = document.createElement('div');
     header.className = 'case-header';
-    header.innerHTML = `<h3>${caseData.name}</h3>`;
+    const title = document.createElement('h3');
+    title.textContent = caseData.name;
+    header.appendChild(title);
+
+    if (categoryLabels[caseData.category]) {
+        const badge = document.createElement('span');
+        badge.className = 'case-category';
+        badge.textContent = categoryLabels[caseData.category];
+        header.appendChild(badge);
+    }
 
     const meta = document.createElement('div');
     meta.className = 'case-meta';
@@ -408,9 +459,34 @@ function createCaseCard(caseData) {
 
 function renderCases() {
     selectors.caseList.innerHTML = '';
-    cases.forEach((caseData) => {
+    const filteredCases = activeFilter === 'all'
+        ? cases
+        : cases.filter((caseData) => caseData.category === activeFilter);
+
+    if (!filteredCases.length) {
+        selectors.caseList.classList.add('empty');
+        selectors.caseList.innerHTML = `
+            <div class="empty-cases">
+                <h3>Нет кейсов в этой категории</h3>
+                <p>Попробуйте выбрать другой фильтр или вернуться позже.</p>
+            </div>
+        `;
+        return;
+    }
+
+    selectors.caseList.classList.remove('empty');
+
+    filteredCases.forEach((caseData) => {
         selectors.caseList.appendChild(createCaseCard(caseData));
     });
+}
+
+function setActiveFilter(filter) {
+    activeFilter = filter;
+    selectors.filterButtons.forEach((button) => {
+        button.classList.toggle('active', button.dataset.filter === filter);
+    });
+    renderCases();
 }
 
 function renderInventory() {
@@ -473,14 +549,14 @@ function openCaseModal(caseData) {
     populateCaseSkins(caseData);
     populateRoulette(caseData);
     selectors.caseModal.classList.remove('hidden');
-    selectors.overlay.classList.remove('hidden');
+    showOverlay();
     selectors.caseModal.setAttribute('aria-hidden', 'false');
 }
 
 function closeCaseModal() {
     if (isSpinning) return;
     selectors.caseModal.classList.add('hidden');
-    selectors.overlay.classList.add('hidden');
+    hideOverlayIfIdle();
     selectors.caseModal.setAttribute('aria-hidden', 'true');
     activeCase = null;
 }
@@ -607,28 +683,121 @@ function addToInventory(skin) {
     renderInventory();
 }
 
-function handleDeposit() {
-    const input = prompt('Введите сумму пополнения (USD):', '50');
-    if (!input) return;
-    const amount = Number(input);
-    if (Number.isNaN(amount) || amount <= 0) {
-        alert('Введите корректную сумму.');
+function clearDepositError() {
+    if (selectors.depositError) {
+        selectors.depositError.textContent = '';
+    }
+    if (selectors.depositAmount) {
+        selectors.depositAmount.setAttribute('aria-invalid', 'false');
+        const group = selectors.depositAmount.closest('.deposit-input-group');
+        if (group) {
+            group.classList.remove('has-error');
+        }
+    }
+}
+
+function showDepositError(message) {
+    if (selectors.depositError) {
+        selectors.depositError.textContent = message;
+    }
+    if (selectors.depositAmount) {
+        selectors.depositAmount.setAttribute('aria-invalid', 'true');
+        const group = selectors.depositAmount.closest('.deposit-input-group');
+        if (group) {
+            group.classList.add('has-error');
+        }
+        selectors.depositAmount.focus();
+    }
+}
+
+function resetDepositForm() {
+    if (selectors.depositForm) {
+        selectors.depositForm.reset();
+    }
+    clearDepositError();
+}
+
+function openDepositModal() {
+    if (!selectors.depositModal) return;
+    resetDepositForm();
+    selectors.depositModal.classList.remove('hidden');
+    selectors.depositModal.setAttribute('aria-hidden', 'false');
+    showOverlay();
+    if (selectors.depositAmount) {
+        requestAnimationFrame(() => selectors.depositAmount.focus());
+    }
+}
+
+function closeDepositModal() {
+    if (!selectors.depositModal) return;
+    selectors.depositModal.classList.add('hidden');
+    selectors.depositModal.setAttribute('aria-hidden', 'true');
+    hideOverlayIfIdle();
+    resetDepositForm();
+}
+
+function handleDepositSubmit(event) {
+    event.preventDefault();
+    if (!selectors.depositAmount) return;
+    const rawValue = selectors.depositAmount.value.trim().replace(/\s+/g, '').replace(/,/g, '.');
+    if (!rawValue) {
+        showDepositError('Введите сумму пополнения.');
         return;
     }
+    const amount = Number.parseFloat(rawValue);
+    if (!Number.isFinite(amount) || amount <= 0) {
+        showDepositError('Укажите сумму больше нуля.');
+        return;
+    }
+    if (amount > 10000) {
+        showDepositError('Максимум $10 000 за одно пополнение.');
+        return;
+    }
+    clearDepositError();
     currentBalance += amount;
     updateBalanceDisplay();
     saveState();
+    closeDepositModal();
 }
 
 function registerEvents() {
     selectors.closeModal.addEventListener('click', closeCaseModal);
-    selectors.overlay.addEventListener('click', closeCaseModal);
+    selectors.overlay.addEventListener('click', () => {
+        if (!isHidden(selectors.depositModal)) {
+            closeDepositModal();
+        }
+        if (!isHidden(selectors.caseModal)) {
+            closeCaseModal();
+        }
+    });
     selectors.openCaseBtn.addEventListener('click', spinRoulette);
-    selectors.depositBtn.addEventListener('click', handleDeposit);
-    selectors.heroDeposit.addEventListener('click', handleDeposit);
+    selectors.depositBtn.addEventListener('click', openDepositModal);
+    selectors.heroDeposit.addEventListener('click', openDepositModal);
+    if (selectors.closeDeposit) {
+        selectors.closeDeposit.addEventListener('click', closeDepositModal);
+    }
+    if (selectors.depositCancel) {
+        selectors.depositCancel.addEventListener('click', closeDepositModal);
+    }
+    if (selectors.depositForm) {
+        selectors.depositForm.addEventListener('submit', handleDepositSubmit);
+    }
+    if (selectors.depositAmount) {
+        selectors.depositAmount.addEventListener('input', clearDepositError);
+    }
+    selectors.filterButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            const filterValue = button.dataset.filter || 'all';
+            setActiveFilter(filterValue);
+        });
+    });
     window.addEventListener('keydown', (event) => {
         if (event.key === 'Escape') {
-            closeCaseModal();
+            if (!isHidden(selectors.depositModal)) {
+                closeDepositModal();
+            } else {
+                closeCaseModal();
+            }
         }
     });
 }
@@ -643,7 +812,7 @@ function init() {
     updateBalanceDisplay();
     updateInventorySummary();
     renderInventory();
-    renderCases();
+    setActiveFilter(activeFilter);
     registerEvents();
 }
 

--- a/app.js
+++ b/app.js
@@ -1,0 +1,650 @@
+const rarityConfig = {
+    milspec: { label: 'Mil-Spec', className: 'rarity-milspec', labelClass: 'rarity-label-milspec', weight: 70 },
+    restricted: { label: 'Restricted', className: 'rarity-restricted', labelClass: 'rarity-label-restricted', weight: 20 },
+    classified: { label: 'Classified', className: 'rarity-classified', labelClass: 'rarity-label-classified', weight: 7 },
+    covert: { label: 'Covert', className: 'rarity-covert', labelClass: 'rarity-label-covert', weight: 2.5 },
+    contraband: { label: 'Contraband', className: 'rarity-contraband', labelClass: 'rarity-label-contraband', weight: 0.4 },
+    rare: { label: 'Засекреченное', className: 'rarity-rare', labelClass: 'rarity-label-rare', weight: 0.3 },
+    legendary: { label: 'Exceedingly Rare', className: 'rarity-legendary', labelClass: 'rarity-label-legendary', weight: 0.1 }
+};
+
+const IMAGE_BASE_URL = 'https://steamcommunity.com/economy/image/item/730/';
+const FALLBACK_IMAGE = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHZpZXdCb3g9JzAgMCAyMDAgMjAwJz48cmVjdCB3aWR0aD0nMjAwJyBoZWlnaHQ9JzIwMCcgZmlsbD0nIzExMTgyNycvPjx0ZXh0IHg9JzUwJScgeT0nNTAlJyBmaWxsPScjOWNhM2FmJyBmb250LWZhbWlseT0nUm9ib3RvLEFyaWFsLHNhbnMtc2VyaWYnIGZvbnQtc2l6ZT0nMjQnIHRleHQtYW5jaG9yPSdtaWRkbGUnIGRvbWluYW50LWJhc2VsaW5lPSdtaWRkbGUnPk5PIElNQUdFPC90ZXh0Pjwvc3ZnPg==';
+
+function toMarketHash({ name, wear, marketHash }) {
+    if (marketHash) {
+        return marketHash;
+    }
+    return wear ? `${name} (${wear})` : name;
+}
+
+function buildImageUrl(descriptor) {
+    if (typeof descriptor === 'string') {
+        return `${IMAGE_BASE_URL}${encodeURIComponent(descriptor)}`;
+    }
+    return `${IMAGE_BASE_URL}${encodeURIComponent(toMarketHash(descriptor))}`;
+}
+
+function applyImage(img, src, alt) {
+    img.loading = 'lazy';
+    img.classList.remove('image-placeholder');
+    delete img.dataset.fallbackApplied;
+    img.alt = alt;
+    img.addEventListener('error', () => {
+        if (img.dataset.fallbackApplied) {
+            return;
+        }
+        img.dataset.fallbackApplied = 'true';
+        img.src = FALLBACK_IMAGE;
+        img.alt = `${alt} (плейсхолдер)`;
+        img.classList.add('image-placeholder');
+    }, { once: true });
+    img.src = src;
+}
+
+const rawCases = [
+    {
+        id: 'phoenix-pro',
+        name: 'Пламя Феникса',
+        price: 6.49,
+        description: 'Сбалансированный набор ярких AR и AWP скинов с шансом на редчайшие дропы.',
+        showcase: [
+            { name: 'AK-47 | Asiimov', wear: 'Field-Tested' },
+            { name: 'AWP | Desert Hydra', wear: 'Field-Tested' },
+            { name: 'M4A1-S | Player Two', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: 'AK-47 | Asiimov', wear: 'Field-Tested', rarity: 'covert', price: 48.3, chance: 0.6 },
+            { name: 'AWP | Desert Hydra', wear: 'Field-Tested', rarity: 'covert', price: 410.0, chance: 0.15 },
+            { name: 'M4A1-S | Player Two', wear: 'Field-Tested', rarity: 'classified', price: 32.4, chance: 2.8 },
+            { name: 'AK-47 | Phantom Disruptor', wear: 'Field-Tested', rarity: 'classified', price: 18.7, chance: 3.5 },
+            { name: 'USP-S | Cortex', wear: 'Field-Tested', rarity: 'restricted', price: 7.4, chance: 9 },
+            { name: 'AWP | Acheron', wear: 'Field-Tested', rarity: 'restricted', price: 9.8, chance: 7 },
+            { name: 'MAC-10 | Sakkaku', wear: 'Minimal Wear', rarity: 'restricted', price: 5.6, chance: 9 },
+            { name: 'Galil AR | Chromatic Aberration', wear: 'Field-Tested', rarity: 'milspec', price: 2.1, chance: 21 },
+            { name: 'FAMAS | Eye of Athena', wear: 'Field-Tested', rarity: 'milspec', price: 1.8, chance: 21 },
+            { name: 'MAG-7 | Justice', wear: 'Field-Tested', rarity: 'milspec', price: 1.6, chance: 26 },
+            { name: '★ Karambit | Lore', wear: 'Field-Tested', rarity: 'legendary', price: 1250, chance: 0.07 },
+            { name: '★ Skeleton Knife | Fade', wear: 'Factory New', rarity: 'legendary', price: 980, chance: 0.08 }
+        ]
+    },
+    {
+        id: 'night-operation',
+        name: 'Ночная операция',
+        price: 9.99,
+        description: 'Всё для тактических ночных рейдов — темные и дорогие скины с шансом на нож.',
+        showcase: [
+            { name: 'M4A1-S | Printstream', wear: 'Field-Tested' },
+            { name: 'USP-S | Printstream', wear: 'Field-Tested' },
+            { name: 'AK-47 | Nightwish', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: 'M4A1-S | Printstream', wear: 'Field-Tested', rarity: 'covert', price: 310, chance: 0.2 },
+            { name: 'USP-S | Printstream', wear: 'Field-Tested', rarity: 'covert', price: 140, chance: 0.5 },
+            { name: 'AK-47 | Nightwish', wear: 'Field-Tested', rarity: 'classified', price: 52, chance: 2.6 },
+            { name: 'MP9 | Starlight Protector', wear: 'Minimal Wear', rarity: 'classified', price: 24, chance: 3 },
+            { name: 'Desert Eagle | Printstream', wear: 'Field-Tested', rarity: 'classified', price: 160, chance: 0.8 },
+            { name: 'AWP | Chromatic Aberration', wear: 'Field-Tested', rarity: 'restricted', price: 19.5, chance: 7 },
+            { name: 'P2000 | Dispatch', wear: 'Field-Tested', rarity: 'restricted', price: 4.5, chance: 8 },
+            { name: 'M4A4 | In Living Color', wear: 'Field-Tested', rarity: 'restricted', price: 8.9, chance: 6.5 },
+            { name: 'Negev | dev_texture', wear: 'Field-Tested', rarity: 'milspec', price: 1.9, chance: 18 },
+            { name: 'Five-SeveN | Boost Protocol', wear: 'Field-Tested', rarity: 'milspec', price: 2.2, chance: 18 },
+            { name: 'Dual Berettas | Melondrama', wear: 'Minimal Wear', rarity: 'milspec', price: 1.4, chance: 18 },
+            { name: '★ Karambit | Doppler', wear: 'Factory New', rarity: 'legendary', price: 1450, chance: 0.05 },
+            { name: '★ Butterfly Knife | Marble Fade', wear: 'Factory New', rarity: 'legendary', price: 1675, chance: 0.03 },
+            { name: 'MP5-SD | Phosphor', wear: 'Field-Tested', rarity: 'restricted', price: 9.4, chance: 3.2 }
+        ]
+    },
+    {
+        id: 'ancient-treasures',
+        name: 'Древние сокровища',
+        price: 3.99,
+        description: 'Доступный кейс с фокусом на окупаемость за счёт редких предметов из древних коллекций.',
+        showcase: [
+            { name: 'AK-47 | Legion of Anubis', wear: 'Field-Tested' },
+            { name: 'M4A1-S | Golden Coil', wear: 'Field-Tested' },
+            { name: 'MAC-10 | Gold Brick', wear: 'Minimal Wear' }
+        ],
+        skins: [
+            { name: 'AK-47 | Legion of Anubis', wear: 'Field-Tested', rarity: 'classified', price: 21.5, chance: 1.4 },
+            { name: 'M4A1-S | Golden Coil', wear: 'Field-Tested', rarity: 'classified', price: 28.7, chance: 1 },
+            { name: 'AK-47 | Aquamarine Revenge', wear: 'Field-Tested', rarity: 'covert', price: 22, chance: 0.8 },
+            { name: 'Glock-18 | Neo-Noir', wear: 'Field-Tested', rarity: 'restricted', price: 12.4, chance: 3 },
+            { name: 'Desert Eagle | Night Heist', wear: 'Field-Tested', rarity: 'restricted', price: 5.8, chance: 4 },
+            { name: 'MAC-10 | Gold Brick', wear: 'Minimal Wear', rarity: 'restricted', price: 4.1, chance: 4 },
+            { name: 'P250 | Cyber Shell', wear: 'Field-Tested', rarity: 'milspec', price: 1.2, chance: 12 },
+            { name: 'Galil AR | Vandal', wear: 'Field-Tested', rarity: 'milspec', price: 1.3, chance: 12 },
+            { name: 'XM1014 | Ancient Lore', wear: 'Field-Tested', rarity: 'milspec', price: 1.1, chance: 12 },
+            { name: 'SSG 08 | Prey', wear: 'Field-Tested', rarity: 'milspec', price: 0.85, chance: 12 },
+            { name: 'AWP | The Prince', wear: 'Minimal Wear', rarity: 'contraband', price: 1700, chance: 0.04 },
+            { name: '★ Talon Knife | Fade', wear: 'Factory New', rarity: 'legendary', price: 1200, chance: 0.03 }
+        ]
+    },
+    {
+        id: 'budget-rush',
+        name: 'Бюджетный прорыв',
+        price: 1.89,
+        description: 'Идеальный кейс для старта — много дешёвых дропов и шанс на редкие апгрейды.',
+        showcase: [
+            { name: 'AK-47 | Slate', wear: 'Field-Tested' },
+            { name: 'AWP | Atheris', wear: 'Field-Tested' },
+            { name: 'MP7 | Abyssal Apparition', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: 'AK-47 | Slate', wear: 'Field-Tested', rarity: 'restricted', price: 7.1, chance: 3.2 },
+            { name: 'AWP | Atheris', wear: 'Field-Tested', rarity: 'restricted', price: 6.2, chance: 3.4 },
+            { name: 'MP7 | Abyssal Apparition', wear: 'Field-Tested', rarity: 'restricted', price: 4.8, chance: 3.5 },
+            { name: 'Desert Eagle | Light Rail', wear: 'Field-Tested', rarity: 'restricted', price: 2.4, chance: 5 },
+            { name: 'P90 | Cocoa Rampage', wear: 'Field-Tested', rarity: 'milspec', price: 1, chance: 12 },
+            { name: 'Five-SeveN | Fairy Tale', wear: 'Field-Tested', rarity: 'milspec', price: 1.3, chance: 12 },
+            { name: 'SG 553 | Phantom', wear: 'Field-Tested', rarity: 'milspec', price: 1.1, chance: 12 },
+            { name: 'Nova | Windblown', wear: 'Field-Tested', rarity: 'milspec', price: 0.9, chance: 12 },
+            { name: 'UMP-45 | Oscillator', wear: 'Field-Tested', rarity: 'milspec', price: 0.6, chance: 15 },
+            { name: 'USP-S | Lead Conduit', wear: 'Field-Tested', rarity: 'milspec', price: 0.75, chance: 15 },
+            { name: 'M4A4 | Spider Lily', wear: 'Field-Tested', rarity: 'classified', price: 28.5, chance: 0.8 },
+            { name: 'AK-47 | Fuel Injector', wear: 'Field-Tested', rarity: 'covert', price: 110, chance: 0.09 }
+        ]
+    },
+    {
+        id: 'knife-express',
+        name: 'Ножевой экспресс',
+        price: 49.99,
+        description: 'Максимальные шансы на ножи и топовые covert-предметы. Лучшее для хайроллеров.',
+        showcase: [
+            { name: '★ Karambit | Gamma Doppler', wear: 'Factory New' },
+            { name: '★ Butterfly Knife | Lore', wear: 'Field-Tested' },
+            { name: 'AWP | Dragon Lore', wear: 'Factory New' }
+        ],
+        skins: [
+            { name: '★ Karambit | Gamma Doppler', wear: 'Factory New', rarity: 'legendary', price: 1900, chance: 0.5 },
+            { name: '★ Butterfly Knife | Lore', wear: 'Field-Tested', rarity: 'legendary', price: 2100, chance: 0.45 },
+            { name: '★ Classic Knife | Fade', wear: 'Factory New', rarity: 'legendary', price: 850, chance: 0.9 },
+            { name: 'AWP | Dragon Lore', wear: 'Factory New', rarity: 'contraband', price: 4600, chance: 0.1 },
+            { name: 'AK-47 | Wild Lotus', wear: 'Field-Tested', rarity: 'covert', price: 2400, chance: 0.2 },
+            { name: 'M4A1-S | Hot Rod', wear: 'Factory New', rarity: 'covert', price: 980, chance: 0.35 },
+            { name: 'Desert Eagle | Fennec Fox', wear: 'Field-Tested', rarity: 'classified', price: 540, chance: 1.4 },
+            { name: 'AK-47 | The Empress', wear: 'Field-Tested', rarity: 'classified', price: 190, chance: 1.6 },
+            { name: 'M4A4 | Royal Paladin', wear: 'Field-Tested', rarity: 'restricted', price: 74, chance: 3 },
+            { name: 'USP-S | Kill Confirmed', wear: 'Field-Tested', rarity: 'restricted', price: 85, chance: 2.8 },
+            { name: 'Five-SeveN | Angry Mob', wear: 'Field-Tested', rarity: 'milspec', price: 16, chance: 6 },
+            { name: 'MP9 | Wild Lily', wear: 'Field-Tested', rarity: 'milspec', price: 12, chance: 6 }
+        ]
+    },
+    {
+        id: 'awp-sanctum',
+        name: 'AWP: Святилище',
+        price: 12.49,
+        description: 'Коллекция из культовых AWP — от легендарного Dragon Lore до бюджетного Mortis.',
+        showcase: [
+            { name: 'AWP | Dragon Lore', wear: 'Factory New' },
+            { name: 'AWP | Gungnir', wear: 'Factory New' },
+            { name: 'AWP | Wildfire', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: 'AWP | Dragon Lore', wear: 'Factory New', rarity: 'contraband', price: 4600, chance: 0.04 },
+            { name: 'AWP | Gungnir', wear: 'Factory New', rarity: 'covert', price: 3100, chance: 0.08 },
+            { name: 'AWP | Desert Hydra', wear: 'Factory New', rarity: 'covert', price: 520, chance: 0.3 },
+            { name: 'AWP | Oni Taiji', wear: 'Field-Tested', rarity: 'covert', price: 145, chance: 0.7 },
+            { name: 'AWP | Wildfire', wear: 'Field-Tested', rarity: 'covert', price: 65, chance: 1.1 },
+            { name: 'AWP | Hyper Beast', wear: 'Field-Tested', rarity: 'classified', price: 28, chance: 3 },
+            { name: 'AWP | Neo-Noir', wear: 'Field-Tested', rarity: 'classified', price: 24, chance: 4 },
+            { name: 'AWP | Atheris', wear: 'Field-Tested', rarity: 'restricted', price: 6.2, chance: 12 },
+            { name: 'AWP | Exoskeleton', wear: 'Field-Tested', rarity: 'restricted', price: 6, chance: 12 },
+            { name: 'AWP | Mortis', wear: 'Field-Tested', rarity: 'restricted', price: 5, chance: 12 },
+            { name: 'AWP | Elite Build', wear: 'Field-Tested', rarity: 'milspec', price: 1.4, chance: 20 },
+            { name: 'AWP | PAW', wear: 'Field-Tested', rarity: 'milspec', price: 1.2, chance: 20 }
+        ]
+    },
+    {
+        id: 'deagle-syndicate',
+        name: 'Синдикат Deagle',
+        price: 7.79,
+        description: 'Только Desert Eagle — от легендарного Blaze до доступного Oxide Blaze.',
+        showcase: [
+            { name: 'Desert Eagle | Blaze', wear: 'Factory New' },
+            { name: 'Desert Eagle | Fennec Fox', wear: 'Field-Tested' },
+            { name: 'Desert Eagle | Printstream', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: 'Desert Eagle | Blaze', wear: 'Factory New', rarity: 'covert', price: 640, chance: 0.25 },
+            { name: 'Desert Eagle | Fennec Fox', wear: 'Field-Tested', rarity: 'classified', price: 540, chance: 0.4 },
+            { name: 'Desert Eagle | Printstream', wear: 'Field-Tested', rarity: 'covert', price: 160, chance: 0.7 },
+            { name: 'Desert Eagle | Ocean Drive', wear: 'Field-Tested', rarity: 'covert', price: 180, chance: 0.65 },
+            { name: 'Desert Eagle | Code Red', wear: 'Field-Tested', rarity: 'classified', price: 68, chance: 1.4 },
+            { name: 'Desert Eagle | Mecha Industries', wear: 'Field-Tested', rarity: 'classified', price: 32, chance: 2.2 },
+            { name: 'Desert Eagle | Kumicho Dragon', wear: 'Field-Tested', rarity: 'classified', price: 45, chance: 2 },
+            { name: 'Desert Eagle | Midnight Storm', wear: 'Field-Tested', rarity: 'restricted', price: 7, chance: 6 },
+            { name: 'Desert Eagle | Light Rail', wear: 'Field-Tested', rarity: 'restricted', price: 6, chance: 6 },
+            { name: 'Desert Eagle | Conspiracy', wear: 'Field-Tested', rarity: 'restricted', price: 5, chance: 6 },
+            { name: 'Desert Eagle | Bronze Deco', wear: 'Field-Tested', rarity: 'milspec', price: 2, chance: 15 },
+            { name: 'Desert Eagle | Sputnik', wear: 'Field-Tested', rarity: 'milspec', price: 1.3, chance: 15 },
+            { name: 'Desert Eagle | Directive', wear: 'Field-Tested', rarity: 'milspec', price: 1.1, chance: 15 },
+            { name: 'Desert Eagle | Oxide Blaze', wear: 'Field-Tested', rarity: 'milspec', price: 0.9, chance: 15 }
+        ]
+    },
+    {
+        id: 'usp-blacksite',
+        name: 'Черный сектор USP',
+        price: 5.89,
+        description: 'Коллекция для ценителей USP-S: редкие неонуары и бюджетные варианты.',
+        showcase: [
+            { name: 'USP-S | Kill Confirmed', wear: 'Field-Tested' },
+            { name: 'USP-S | Printstream', wear: 'Field-Tested' },
+            { name: 'USP-S | Neo-Noir', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: 'USP-S | Printstream', wear: 'Field-Tested', rarity: 'covert', price: 140, chance: 0.9 },
+            { name: 'USP-S | Kill Confirmed', wear: 'Field-Tested', rarity: 'classified', price: 85, chance: 1.1 },
+            { name: 'USP-S | Neo-Noir', wear: 'Field-Tested', rarity: 'classified', price: 35, chance: 2 },
+            { name: 'USP-S | Road Rash', wear: 'Field-Tested', rarity: 'classified', price: 48, chance: 1.5 },
+            { name: 'USP-S | Orion', wear: 'Field-Tested', rarity: 'classified', price: 62, chance: 1.1 },
+            { name: 'USP-S | Target Acquired', wear: 'Field-Tested', rarity: 'classified', price: 28, chance: 2.4 },
+            { name: 'USP-S | Cortex', wear: 'Field-Tested', rarity: 'restricted', price: 7.4, chance: 6 },
+            { name: 'USP-S | Black Lotus', wear: 'Field-Tested', rarity: 'restricted', price: 4.6, chance: 6 },
+            { name: 'USP-S | Monster Mashup', wear: 'Field-Tested', rarity: 'restricted', price: 6, chance: 6 },
+            { name: 'USP-S | Stainless', wear: 'Field-Tested', rarity: 'restricted', price: 3.5, chance: 6 },
+            { name: 'USP-S | Ticket to Hell', wear: 'Field-Tested', rarity: 'milspec', price: 2, chance: 15 },
+            { name: 'USP-S | Flashback', wear: 'Field-Tested', rarity: 'milspec', price: 1, chance: 15 },
+            { name: 'USP-S | Night Ops', wear: 'Field-Tested', rarity: 'milspec', price: 0.8, chance: 15 },
+            { name: 'USP-S | Torque', wear: 'Field-Tested', rarity: 'milspec', price: 1.1, chance: 15 }
+        ]
+    },
+    {
+        id: 'farm-gold',
+        name: 'Фарм кейс: Золотая охота',
+        price: 2.59,
+        description: 'Один шанс на золотой нож и гора ширпа для фарма контрактов.',
+        showcase: [
+            { name: '★ Butterfly Knife | Lore', wear: 'Field-Tested' },
+            { name: 'AK-47 | Safari Mesh', wear: 'Field-Tested' },
+            { name: 'Glock-18 | Groundwater', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: '★ Butterfly Knife | Lore', wear: 'Field-Tested', rarity: 'legendary', price: 1600, chance: 0.05 },
+            { name: 'AK-47 | Safari Mesh', wear: 'Field-Tested', rarity: 'milspec', price: 0.45, chance: 16.6 },
+            { name: 'Five-SeveN | Contractor', wear: 'Field-Tested', rarity: 'milspec', price: 0.12, chance: 16.6 },
+            { name: 'Tec-9 | VariCamo', wear: 'Field-Tested', rarity: 'milspec', price: 0.13, chance: 16.6 },
+            { name: 'SCAR-20 | Sand Mesh', wear: 'Field-Tested', rarity: 'milspec', price: 0.09, chance: 16.6 },
+            { name: 'M249 | Submerged', wear: 'Field-Tested', rarity: 'milspec', price: 0.2, chance: 16.6 },
+            { name: 'Glock-18 | Groundwater', wear: 'Field-Tested', rarity: 'milspec', price: 0.35, chance: 16.6 }
+        ]
+    },
+    {
+        id: 'farm-emerald',
+        name: 'Фарм кейс: Изумрудный миф',
+        price: 3.19,
+        description: 'Мизерный шанс на изумрудный карамбит и куча дешёвых пушек для апгрейдов.',
+        showcase: [
+            { name: '★ Karambit | Gamma Doppler', wear: 'Factory New' },
+            { name: 'P90 | Sand Spray', wear: 'Field-Tested' },
+            { name: 'UMP-45 | Fallout Warning', wear: 'Field-Tested' }
+        ],
+        skins: [
+            { name: '★ Karambit | Gamma Doppler', wear: 'Factory New', rarity: 'legendary', price: 1900, chance: 0.03 },
+            { name: 'P90 | Sand Spray', wear: 'Field-Tested', rarity: 'milspec', price: 0.25, chance: 16.2 },
+            { name: 'UMP-45 | Fallout Warning', wear: 'Field-Tested', rarity: 'milspec', price: 0.2, chance: 16.2 },
+            { name: 'XM1014 | Blue Steel', wear: 'Field-Tested', rarity: 'milspec', price: 0.3, chance: 16.2 },
+            { name: 'MAC-10 | Candy Apple', wear: 'Field-Tested', rarity: 'milspec', price: 0.22, chance: 16.2 },
+            { name: 'MP9 | Sand Scale', wear: 'Field-Tested', rarity: 'milspec', price: 0.16, chance: 16.2 },
+            { name: 'G3SG1 | Desert Storm', wear: 'Field-Tested', rarity: 'milspec', price: 0.18, chance: 16.2 }
+        ]
+    }
+];
+
+const cases = rawCases.map((caseData) => ({
+    ...caseData,
+    showcase: caseData.showcase.map((entry) => buildImageUrl(entry)),
+    skins: caseData.skins.map((skin) => {
+        const marketHash = toMarketHash(skin);
+        const fullName = skin.displayName || (skin.wear ? `${skin.name} (${skin.wear})` : skin.name);
+        return {
+            ...skin,
+            wear: skin.wear ?? null,
+            marketHash,
+            fullName,
+            image: buildImageUrl(marketHash)
+        };
+    })
+}));
+
+const selectors = {
+    balance: document.getElementById('balance'),
+    inventoryGrid: document.getElementById('inventoryGrid'),
+    inventoryValue: document.getElementById('inventoryValue'),
+    inventoryCount: document.getElementById('inventoryCount'),
+    caseList: document.getElementById('caseList'),
+    caseModal: document.getElementById('caseModal'),
+    overlay: document.getElementById('overlay'),
+    modalCaseName: document.getElementById('modalCaseName'),
+    modalCaseDescription: document.getElementById('modalCaseDescription'),
+    modalCasePrice: document.getElementById('modalCasePrice'),
+    caseSkinsGrid: document.getElementById('caseSkinsGrid'),
+    openCaseBtn: document.getElementById('openCaseBtn'),
+    rouletteStrip: document.getElementById('rouletteStrip'),
+    rouletteResult: document.getElementById('rouletteResult'),
+    closeModal: document.getElementById('closeModal'),
+    depositBtn: document.getElementById('depositBtn'),
+    heroDeposit: document.getElementById('heroDeposit'),
+};
+
+let currentBalance = Number(localStorage.getItem('cs2-case-balance')) || 150.00;
+let inventory = JSON.parse(localStorage.getItem('cs2-case-inventory') || '[]');
+let legacyInventoryMigrated = false;
+inventory = inventory.map((item) => {
+    const fullName = item.fullName || (item.wear ? `${item.name} (${item.wear})` : item.name);
+    const needsImageRefresh = !item.image || /csgostash|skin_sideview/.test(item.image);
+    if (needsImageRefresh) {
+        legacyInventoryMigrated = true;
+    }
+    return {
+        ...item,
+        fullName,
+        marketHash: item.marketHash || fullName,
+        image: needsImageRefresh ? buildImageUrl(fullName) : item.image
+    };
+});
+if (legacyInventoryMigrated) {
+    saveState();
+}
+let activeCase = null;
+let isSpinning = false;
+
+function formatCurrency(value) {
+    return `$${value.toFixed(2)}`;
+}
+
+function saveState() {
+    localStorage.setItem('cs2-case-balance', currentBalance.toFixed(2));
+    localStorage.setItem('cs2-case-inventory', JSON.stringify(inventory));
+}
+
+function updateBalanceDisplay() {
+    selectors.balance.textContent = formatCurrency(currentBalance);
+}
+
+function updateInventorySummary() {
+    const totalValue = inventory.reduce((sum, item) => sum + item.price, 0);
+    selectors.inventoryValue.textContent = formatCurrency(totalValue);
+    selectors.inventoryCount.textContent = inventory.length.toString();
+}
+
+function createCaseCard(caseData) {
+    const card = document.createElement('article');
+    card.className = 'case-card';
+
+    const header = document.createElement('div');
+    header.className = 'case-header';
+    header.innerHTML = `<h3>${caseData.name}</h3>`;
+
+    const meta = document.createElement('div');
+    meta.className = 'case-meta';
+    meta.innerHTML = `<span>${caseData.skins.length} предметов</span><span>${formatCurrency(caseData.price)}</span>`;
+
+    const preview = document.createElement('div');
+    preview.className = 'case-preview';
+    caseData.showcase.forEach((src) => {
+        const img = document.createElement('img');
+        applyImage(img, src, `${caseData.name} превью`);
+        preview.appendChild(img);
+    });
+
+    const description = document.createElement('p');
+    description.textContent = caseData.description;
+    description.className = 'case-description';
+
+    const openBtn = document.createElement('button');
+    openBtn.className = 'btn primary';
+    openBtn.textContent = `Открыть за ${formatCurrency(caseData.price)}`;
+    openBtn.addEventListener('click', () => openCaseModal(caseData));
+
+    card.append(header, meta, preview, description, openBtn);
+    card.addEventListener('click', (event) => {
+        if (event.target === openBtn) return;
+        openCaseModal(caseData);
+    });
+
+    return card;
+}
+
+function renderCases() {
+    selectors.caseList.innerHTML = '';
+    cases.forEach((caseData) => {
+        selectors.caseList.appendChild(createCaseCard(caseData));
+    });
+}
+
+function renderInventory() {
+    selectors.inventoryGrid.innerHTML = '';
+    if (!inventory.length) {
+        selectors.inventoryGrid.classList.add('empty-state');
+        selectors.inventoryGrid.innerHTML = `
+            <div class="empty-message">
+                <h3>Инвентарь пуст</h3>
+                <p>Открой кейс, чтобы начать коллекцию.</p>
+            </div>
+        `;
+        return;
+    }
+
+    selectors.inventoryGrid.classList.remove('empty-state');
+    inventory.forEach((item, index) => {
+        const card = document.getElementById('skinCardTemplate').content.firstElementChild.cloneNode(true);
+        const img = card.querySelector('img');
+        const title = card.querySelector('h5');
+        const rarity = card.querySelector('.rarity');
+        const price = card.querySelector('.skin-price');
+        const sellBtn = card.querySelector('.sell-btn');
+        const withdrawBtn = card.querySelector('.withdraw-btn');
+
+        applyImage(img, item.image, item.fullName);
+        title.textContent = item.fullName;
+        rarity.textContent = rarityConfig[item.rarity].label;
+        rarity.classList.add(rarityConfig[item.rarity].labelClass);
+        price.textContent = formatCurrency(item.price);
+
+        sellBtn.addEventListener('click', () => {
+            currentBalance += item.price;
+            inventory.splice(index, 1);
+            updateBalanceDisplay();
+            updateInventorySummary();
+            renderInventory();
+            saveState();
+        });
+
+        withdrawBtn.addEventListener('click', () => {
+            inventory.splice(index, 1);
+            updateInventorySummary();
+            renderInventory();
+            saveState();
+        });
+
+        selectors.inventoryGrid.appendChild(card);
+    });
+}
+
+function openCaseModal(caseData) {
+    if (isSpinning) return;
+    activeCase = caseData;
+    selectors.modalCaseName.textContent = caseData.name;
+    selectors.modalCaseDescription.textContent = caseData.description;
+    selectors.modalCasePrice.textContent = formatCurrency(caseData.price);
+    selectors.openCaseBtn.textContent = `Открыть за ${formatCurrency(caseData.price)}`;
+    selectors.rouletteResult.textContent = '';
+    populateCaseSkins(caseData);
+    populateRoulette(caseData);
+    selectors.caseModal.classList.remove('hidden');
+    selectors.overlay.classList.remove('hidden');
+    selectors.caseModal.setAttribute('aria-hidden', 'false');
+}
+
+function closeCaseModal() {
+    if (isSpinning) return;
+    selectors.caseModal.classList.add('hidden');
+    selectors.overlay.classList.add('hidden');
+    selectors.caseModal.setAttribute('aria-hidden', 'true');
+    activeCase = null;
+}
+
+function populateCaseSkins(caseData) {
+    selectors.caseSkinsGrid.innerHTML = '';
+    caseData.skins.forEach((skin) => {
+        const card = document.createElement('div');
+        card.className = `skin-card ${rarityConfig[skin.rarity].className}`;
+
+        const image = document.createElement('img');
+        applyImage(image, skin.image, skin.fullName);
+
+        const info = document.createElement('div');
+        info.className = 'skin-info';
+        const title = document.createElement('h5');
+        title.textContent = skin.fullName;
+        const rarityBadge = document.createElement('span');
+        rarityBadge.className = `rarity ${rarityConfig[skin.rarity].labelClass}`;
+        rarityBadge.textContent = rarityConfig[skin.rarity].label;
+        info.append(title, rarityBadge);
+
+        const price = document.createElement('div');
+        price.className = 'skin-price';
+        price.textContent = formatCurrency(skin.price);
+
+        const chance = document.createElement('div');
+        chance.className = 'drop-chance';
+        chance.textContent = `Шанс: ${(skin.chance).toFixed(2)}%`;
+
+        card.append(image, info, price, chance);
+        selectors.caseSkinsGrid.appendChild(card);
+    });
+}
+
+function renderRouletteSlot(container, skin) {
+    container.innerHTML = '';
+    const image = document.createElement('img');
+    applyImage(image, skin.image, skin.fullName);
+    const title = document.createElement('strong');
+    title.textContent = skin.fullName;
+    const rarityBadge = document.createElement('span');
+    rarityBadge.className = `rarity ${rarityConfig[skin.rarity].labelClass}`;
+    rarityBadge.textContent = rarityConfig[skin.rarity].label;
+    container.append(image, title, rarityBadge);
+}
+
+function populateRoulette(caseData) {
+    selectors.rouletteStrip.innerHTML = '';
+    const sample = buildRouletteSample(caseData.skins);
+    sample.forEach((skin) => {
+        const card = document.createElement('div');
+        card.className = 'roulette-card';
+        renderRouletteSlot(card, skin);
+        selectors.rouletteStrip.appendChild(card);
+    });
+}
+
+function buildRouletteSample(skins) {
+    const sample = [];
+    for (let i = 0; i < 60; i++) {
+        sample.push(weightedRandomSkin(skins));
+    }
+    return sample;
+}
+
+function weightedRandomSkin(skins) {
+    const totalWeight = skins.reduce((sum, skin) => sum + skin.chance, 0);
+    const roll = Math.random() * totalWeight;
+    let cumulative = 0;
+    for (const skin of skins) {
+        cumulative += skin.chance;
+        if (roll <= cumulative) {
+            return skin;
+        }
+    }
+    return skins[skins.length - 1];
+}
+
+function spinRoulette() {
+    if (!activeCase || isSpinning) return;
+    if (currentBalance < activeCase.price) {
+        selectors.rouletteResult.textContent = 'Недостаточно средств. Пополните баланс.';
+        return;
+    }
+
+    currentBalance -= activeCase.price;
+    updateBalanceDisplay();
+    saveState();
+
+    isSpinning = true;
+    selectors.openCaseBtn.disabled = true;
+    selectors.openCaseBtn.textContent = 'Открываем...';
+
+    const sample = Array.from(selectors.rouletteStrip.children);
+    const winningSkin = weightedRandomSkin(activeCase.skins);
+    const winningIndex = Math.floor(Math.random() * (sample.length - 10)) + 5;
+
+    renderRouletteSlot(sample[winningIndex], winningSkin);
+
+    const targetOffset = -(winningIndex * 160) + (selectors.rouletteStrip.parentElement.offsetWidth / 2) - 70;
+    requestAnimationFrame(() => {
+        selectors.rouletteStrip.style.transition = 'transform 4s cubic-bezier(0.22, 1, 0.36, 1)';
+        selectors.rouletteStrip.style.transform = `translateX(${targetOffset}px)`;
+    });
+
+    setTimeout(() => {
+        selectors.rouletteResult.innerHTML = `Вам выпал <strong>${winningSkin.fullName}</strong> (${formatCurrency(winningSkin.price)})!`;
+        addToInventory(winningSkin);
+        selectors.openCaseBtn.disabled = false;
+        selectors.openCaseBtn.textContent = `Открыть за ${formatCurrency(activeCase.price)}`;
+        isSpinning = false;
+        selectors.rouletteStrip.style.transition = 'none';
+        selectors.rouletteStrip.style.transform = 'translateX(0)';
+        populateRoulette(activeCase);
+        saveState();
+    }, 4200);
+}
+
+function addToInventory(skin) {
+    const newSkin = { ...skin, id: crypto.randomUUID() };
+    inventory.unshift(newSkin);
+    updateInventorySummary();
+    renderInventory();
+}
+
+function handleDeposit() {
+    const input = prompt('Введите сумму пополнения (USD):', '50');
+    if (!input) return;
+    const amount = Number(input);
+    if (Number.isNaN(amount) || amount <= 0) {
+        alert('Введите корректную сумму.');
+        return;
+    }
+    currentBalance += amount;
+    updateBalanceDisplay();
+    saveState();
+}
+
+function registerEvents() {
+    selectors.closeModal.addEventListener('click', closeCaseModal);
+    selectors.overlay.addEventListener('click', closeCaseModal);
+    selectors.openCaseBtn.addEventListener('click', spinRoulette);
+    selectors.depositBtn.addEventListener('click', handleDeposit);
+    selectors.heroDeposit.addEventListener('click', handleDeposit);
+    window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            closeCaseModal();
+        }
+    });
+}
+
+function init() {
+    document.querySelectorAll('[data-apply-fallback]').forEach((img) => {
+        const src = img.getAttribute('src');
+        if (!src) return;
+        const alt = img.getAttribute('alt') || 'Skin preview';
+        applyImage(img, src, alt);
+    });
+    updateBalanceDisplay();
+    updateInventorySummary();
+    renderInventory();
+    renderCases();
+    registerEvents();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CS2 Case Forge</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Russo+One&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="top-bar">
+        <div class="logo">CS2 CASE FORGE</div>
+        <nav class="nav-links">
+            <a href="#cases">Кейсы</a>
+            <a href="#inventory">Инвентарь</a>
+            <a href="#about">О нас</a>
+        </nav>
+        <div class="balance-panel">
+            <span class="balance-label">Баланс:</span>
+            <span id="balance">$0.00</span>
+            <button id="depositBtn" class="btn secondary">Пополнить</button>
+        </div>
+    </header>
+
+    <main>
+        <section class="hero">
+            <div class="hero-content">
+                <h1>Открывай лучшие кейсы CS2</h1>
+                <p>Реалистичная симуляция дропа с актуальными скинами и редкостями. Собери инвентарь мечты и управляй им прямо здесь.</p>
+                <button id="heroDeposit" class="btn primary">Пополнить баланс</button>
+            </div>
+            <div class="hero-showcase">
+                <div class="showcase-card rare">
+                    <img data-apply-fallback src="https://steamcommunity.com/economy/image/item/730/AK-47%20%7C%20Bloodsport%20%28Field-Tested%29" alt="AK-47 | Bloodsport (Field-Tested)">
+                    <span>AK-47 | Bloodsport</span>
+                </div>
+                <div class="showcase-card covert">
+                    <img data-apply-fallback src="https://steamcommunity.com/economy/image/item/730/AWP%20%7C%20Desert%20Hydra%20%28Field-Tested%29" alt="AWP | Desert Hydra (Field-Tested)">
+                    <span>AWP | Desert Hydra</span>
+                </div>
+                <div class="showcase-card legendary">
+                    <img data-apply-fallback src="https://steamcommunity.com/economy/image/item/730/M4A1-S%20%7C%20Printstream%20%28Field-Tested%29" alt="M4A1-S | Printstream (Field-Tested)">
+                    <span>M4A1-S | Printstream</span>
+                </div>
+            </div>
+        </section>
+
+        <section id="cases" class="cases-section">
+            <div class="section-header">
+                <h2>Кейсы</h2>
+                <p>Выбирай из уникальных коллекций с тщательно настроенными шансами.</p>
+            </div>
+            <div id="caseList" class="case-grid"></div>
+        </section>
+
+        <section id="inventory" class="inventory-section">
+            <div class="section-header">
+                <h2>Инвентарь</h2>
+                <p>Управляй своими скинами: продавай или выводи на маркет.</p>
+            </div>
+            <div class="inventory-summary">
+                <div>
+                    <span>Общая стоимость инвентаря</span>
+                    <strong id="inventoryValue">$0.00</strong>
+                </div>
+                <div>
+                    <span>Всего предметов</span>
+                    <strong id="inventoryCount">0</strong>
+                </div>
+            </div>
+            <div id="inventoryGrid" class="inventory-grid empty-state">
+                <div class="empty-message">
+                    <h3>Инвентарь пуст</h3>
+                    <p>Открой кейс, чтобы получить свой первый скин.</p>
+                </div>
+            </div>
+        </section>
+
+        <section id="about" class="about-section">
+            <div class="section-header">
+                <h2>Почему мы?</h2>
+            </div>
+            <div class="about-grid">
+                <div class="about-card">
+                    <h3>Продвинутая математика дропа</h3>
+                    <p>Мы моделируем шансы выпадения с учётом редкостей CS2, чтобы обеспечить честный и захватывающий опыт.</p>
+                </div>
+                <div class="about-card">
+                    <h3>Прозрачный баланс</h3>
+                    <p>Каждое действие влияет на баланс. Продавай скины, выводи или копи на премиальные кейсы.</p>
+                </div>
+                <div class="about-card">
+                    <h3>Живой инвентарь</h3>
+                    <p>Визуальная коллекция твоих трофеев с моментальными действиями. Сохраняем прогресс в браузере.</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>© 2024 CS2 Case Forge. Симулятор, не связанный с Valve.</p>
+    </footer>
+
+    <div id="caseModal" class="modal hidden" aria-hidden="true">
+        <div class="modal-content">
+            <button class="modal-close" id="closeModal" aria-label="Закрыть">×</button>
+            <div class="modal-header">
+                <div>
+                    <h3 id="modalCaseName">Название кейса</h3>
+                    <p id="modalCaseDescription"></p>
+                </div>
+                <div class="modal-price">
+                    <span>Стоимость открытия</span>
+                    <strong id="modalCasePrice">$0.00</strong>
+                </div>
+            </div>
+            <div class="roulette-wrapper">
+                <div class="roulette-window">
+                    <div id="rouletteStrip" class="roulette-strip"></div>
+                    <div class="roulette-indicator"></div>
+                </div>
+                <button id="openCaseBtn" class="btn primary">Открыть</button>
+                <div id="rouletteResult" class="roulette-result" role="status"></div>
+            </div>
+            <div class="case-skins">
+                <h4>Содержимое кейса</h4>
+                <div id="caseSkinsGrid" class="skins-grid"></div>
+            </div>
+        </div>
+    </div>
+
+    <div id="overlay" class="overlay hidden"></div>
+
+    <template id="skinCardTemplate">
+        <div class="skin-card">
+            <img src="" alt="">
+            <div class="skin-info">
+                <h5></h5>
+                <span class="rarity"></span>
+            </div>
+            <div class="skin-price"></div>
+            <div class="card-actions">
+                <button class="btn secondary sell-btn">Продать</button>
+                <button class="btn outline withdraw-btn">Вывести</button>
+            </div>
+        </div>
+    </template>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -52,6 +52,15 @@
                 <h2>Кейсы</h2>
                 <p>Выбирай из уникальных коллекций с тщательно настроенными шансами.</p>
             </div>
+            <div class="case-filters" role="group" aria-label="Категории кейсов">
+                <button class="filter-btn active" data-filter="all">Все</button>
+                <button class="filter-btn" data-filter="featured">Топ</button>
+                <button class="filter-btn" data-filter="premium">Премиум</button>
+                <button class="filter-btn" data-filter="awp">AWP</button>
+                <button class="filter-btn" data-filter="pistol">Пистолеты</button>
+                <button class="filter-btn" data-filter="farm">Фарм</button>
+                <button class="filter-btn" data-filter="budget">Бюджет</button>
+            </div>
             <div id="caseList" class="case-grid"></div>
         </section>
 
@@ -128,6 +137,30 @@
                 <h4>Содержимое кейса</h4>
                 <div id="caseSkinsGrid" class="skins-grid"></div>
             </div>
+        </div>
+    </div>
+
+    <div id="depositModal" class="modal deposit hidden" aria-hidden="true">
+        <div class="modal-content">
+            <button class="modal-close" id="closeDeposit" aria-label="Закрыть">×</button>
+            <div class="modal-header deposit-header">
+                <div>
+                    <h3>Пополнение баланса</h3>
+                    <p>Введите сумму пополнения, чтобы открыть ещё больше кейсов.</p>
+                </div>
+            </div>
+            <form id="depositForm" class="deposit-form" novalidate>
+                <label for="depositAmount">Сумма пополнения (USD)</label>
+                <div class="deposit-input-group">
+                    <span>$</span>
+                    <input id="depositAmount" name="depositAmount" type="number" min="1" max="10000" step="0.01" inputmode="decimal" placeholder="50" required>
+                </div>
+                <p id="depositError" class="form-error" role="alert" aria-live="assertive"></p>
+                <div class="modal-actions">
+                    <button type="submit" class="btn primary">Пополнить</button>
+                    <button type="button" class="btn outline" id="depositCancel">Отмена</button>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,598 @@
+:root {
+    --bg-color: #060915;
+    --bg-elevated: #10162b;
+    --bg-accent: #131c38;
+    --primary: #ffb400;
+    --primary-dark: #d89400;
+    --text-main: #f5f6fb;
+    --text-muted: #a6a9c3;
+    --border: rgba(255, 255, 255, 0.08);
+    --rarity-milspec: #4b69ff;
+    --rarity-restricted: #8847ff;
+    --rarity-classified: #d32ce6;
+    --rarity-covert: #eb4b4b;
+    --rarity-contraband: #ffd700;
+    --rarity-rare: #5e98d9;
+    --rarity-legendary: #ffae00;
+    --success: #65c466;
+    --danger: #e74c3c;
+    --gradient: linear-gradient(135deg, rgba(255, 180, 0, 0.25), rgba(136, 71, 255, 0.3));
+    --transition: 0.3s ease;
+    font-size: 16px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Roboto', sans-serif;
+    background: radial-gradient(circle at top, rgba(255, 180, 0, 0.05), transparent 40%), var(--bg-color);
+    color: var(--text-main);
+    min-height: 100vh;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+img.image-placeholder {
+    object-fit: contain;
+    background: linear-gradient(135deg, rgba(255, 180, 0, 0.12), rgba(136, 71, 255, 0.12));
+    border: 1px dashed rgba(255, 255, 255, 0.22);
+}
+
+.top-bar {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1rem 3vw;
+    background: rgba(6, 9, 21, 0.95);
+    backdrop-filter: blur(18px);
+    border-bottom: 1px solid var(--border);
+}
+
+.logo {
+    font-family: 'Russo One', sans-serif;
+    letter-spacing: 2px;
+    font-size: 1.4rem;
+}
+
+.nav-links {
+    display: flex;
+    gap: 1.5rem;
+    font-weight: 500;
+}
+
+.balance-panel {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: var(--bg-accent);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 0.5rem 1rem;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.3);
+}
+
+.balance-label {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.btn {
+    border: none;
+    border-radius: 999px;
+    padding: 0.55rem 1.3rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.btn.primary {
+    background: linear-gradient(135deg, #ffb400, #ff6200);
+    color: #1a1203;
+    box-shadow: 0 10px 20px rgba(255, 180, 0, 0.25);
+}
+
+.btn.primary:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 26px rgba(255, 180, 0, 0.4);
+}
+
+.btn.secondary {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-main);
+}
+
+.btn.secondary:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.btn.outline {
+    background: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    color: var(--text-main);
+}
+
+.btn.outline:hover {
+    border-color: rgba(255, 255, 255, 0.3);
+}
+
+main {
+    padding: 2rem 4vw 4rem;
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: center;
+    gap: 3rem;
+    padding: 4rem 0;
+}
+
+.hero-content h1 {
+    font-family: 'Russo One', sans-serif;
+    font-size: clamp(2.5rem, 5vw, 3.5rem);
+    margin-bottom: 1rem;
+}
+
+.hero-content p {
+    color: var(--text-muted);
+    font-size: 1.05rem;
+    line-height: 1.7;
+    margin-bottom: 1.5rem;
+}
+
+.hero-showcase {
+    display: grid;
+    gap: 1rem;
+}
+
+.showcase-card {
+    position: relative;
+    padding: 1rem;
+    border-radius: 1.2rem;
+    background: var(--bg-elevated);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: inset 0 0 30px rgba(255, 180, 0, 0.05);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+    text-align: center;
+}
+
+.showcase-card img {
+    width: 200px;
+    max-width: 100%;
+    filter: drop-shadow(0 12px 20px rgba(0, 0, 0, 0.45));
+}
+
+.showcase-card span {
+    font-weight: 600;
+    letter-spacing: 0.5px;
+}
+
+.section-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 2rem;
+    gap: 1rem;
+}
+
+.section-header h2 {
+    font-size: 2rem;
+    margin: 0;
+}
+
+.section-header p {
+    color: var(--text-muted);
+    margin: 0;
+    max-width: 460px;
+}
+
+.case-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.case-card {
+    position: relative;
+    overflow: hidden;
+    padding: 1.5rem;
+    border-radius: 1.2rem;
+    background: var(--bg-elevated);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 18px 30px rgba(0, 0, 0, 0.25);
+    transition: transform var(--transition), box-shadow var(--transition);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.case-card:hover {
+    transform: translateY(-6px);
+    box-shadow: 0 22px 38px rgba(0, 0, 0, 0.35);
+}
+
+.case-card h3 {
+    margin: 0;
+    font-size: 1.35rem;
+}
+
+.case-card .case-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+}
+
+.case-preview {
+    display: flex;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+}
+
+.case-preview img {
+    width: 60px;
+    border-radius: 0.6rem;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(255, 255, 255, 0.03);
+    padding: 0.4rem;
+}
+
+.inventory-section {
+    margin-top: 5rem;
+}
+
+.inventory-summary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
+    background: var(--bg-elevated);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.inventory-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+    transition: opacity var(--transition);
+}
+
+.inventory-grid.empty-state {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 2px dashed rgba(255, 255, 255, 0.08);
+    border-radius: 1rem;
+    min-height: 220px;
+    padding: 2rem;
+}
+
+.empty-message {
+    text-align: center;
+    color: var(--text-muted);
+}
+
+.skin-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+    background: var(--bg-elevated);
+    border-radius: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25);
+    position: relative;
+    overflow: hidden;
+}
+
+.skin-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    background: var(--gradient);
+    transition: opacity var(--transition);
+    z-index: 0;
+}
+
+.skin-card:hover::before {
+    opacity: 1;
+}
+
+.skin-card img {
+    width: 100%;
+    height: 140px;
+    object-fit: contain;
+    filter: drop-shadow(0 16px 22px rgba(0, 0, 0, 0.35));
+    z-index: 1;
+}
+
+.skin-info {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: 1;
+}
+
+.skin-info h5 {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.skin-info .rarity {
+    font-size: 0.75rem;
+    font-weight: 600;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+}
+
+.skin-price {
+    font-weight: 600;
+    z-index: 1;
+}
+
+.card-actions {
+    display: flex;
+    gap: 0.5rem;
+    z-index: 1;
+}
+
+.card-actions .btn {
+    flex: 1;
+    font-size: 0.85rem;
+}
+
+.about-section {
+    margin-top: 6rem;
+    background: linear-gradient(180deg, rgba(16, 22, 43, 0.8), rgba(16, 22, 43, 0));
+    padding-bottom: 5rem;
+}
+
+.about-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1.5rem;
+}
+
+.about-card {
+    padding: 1.5rem;
+    background: var(--bg-elevated);
+    border-radius: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    box-shadow: 0 14px 28px rgba(0, 0, 0, 0.25);
+}
+
+.about-card h3 {
+    margin-top: 0;
+}
+
+.footer {
+    text-align: center;
+    padding: 2rem;
+    color: var(--text-muted);
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
+    background: rgba(6, 9, 21, 0.8);
+}
+
+.modal {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    transition: opacity var(--transition), transform var(--transition);
+}
+
+.modal.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    backdrop-filter: blur(4px);
+    z-index: 90;
+    transition: opacity var(--transition);
+}
+
+.overlay.hidden {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.modal-content {
+    width: min(960px, 90vw);
+    max-height: 90vh;
+    overflow-y: auto;
+    background: var(--bg-color);
+    border-radius: 1.5rem;
+    padding: 2rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
+    position: relative;
+}
+
+.modal-close {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+}
+
+.modal-price span {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    letter-spacing: 1px;
+}
+
+.modal-price strong {
+    font-size: 1.4rem;
+}
+
+.roulette-wrapper {
+    margin: 2rem 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.roulette-window {
+    position: relative;
+    overflow: hidden;
+    border-radius: 1rem;
+    border: 2px solid rgba(255, 255, 255, 0.08);
+    background: rgba(0, 0, 0, 0.4);
+    height: 180px;
+}
+
+.roulette-strip {
+    display: flex;
+    gap: 1rem;
+    padding: 1rem;
+    transform: translateX(0);
+    transition: transform 4s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.roulette-indicator {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 4px;
+    background: linear-gradient(180deg, transparent, rgba(255, 255, 255, 0.8), transparent);
+    box-shadow: 0 0 18px rgba(255, 255, 255, 0.6);
+}
+
+.roulette-card {
+    width: 140px;
+    min-width: 140px;
+    background: var(--bg-elevated);
+    border-radius: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    padding: 0.75rem;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.roulette-card img {
+    width: 120px;
+    max-width: 100%;
+    margin: 0 auto;
+}
+
+.roulette-card .rarity {
+    font-size: 0.7rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 999px;
+    display: inline-block;
+    text-transform: uppercase;
+}
+
+.roulette-result {
+    min-height: 1.5rem;
+    font-weight: 600;
+}
+
+.skins-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.skins-grid .skin-card {
+    padding: 0.75rem;
+}
+
+.drop-chance {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    z-index: 1;
+}
+
+.rarity-milspec { background: rgba(75, 105, 255, 0.2); border: 1px solid rgba(75, 105, 255, 0.4); }
+.rarity-restricted { background: rgba(136, 71, 255, 0.2); border: 1px solid rgba(136, 71, 255, 0.4); }
+.rarity-classified { background: rgba(211, 44, 230, 0.2); border: 1px solid rgba(211, 44, 230, 0.4); }
+.rarity-covert { background: rgba(235, 75, 75, 0.2); border: 1px solid rgba(235, 75, 75, 0.4); }
+.rarity-contraband { background: rgba(255, 215, 0, 0.2); border: 1px solid rgba(255, 215, 0, 0.4); }
+.rarity-rare { background: rgba(94, 152, 217, 0.2); border: 1px solid rgba(94, 152, 217, 0.4); }
+.rarity-legendary { background: rgba(255, 174, 0, 0.25); border: 1px solid rgba(255, 174, 0, 0.45); }
+
+.rarity-label-milspec { color: #4b69ff; }
+.rarity-label-restricted { color: #8847ff; }
+.rarity-label-classified { color: #d32ce6; }
+.rarity-label-covert { color: #eb4b4b; }
+.rarity-label-contraband { color: #ffd700; }
+.rarity-label-rare { color: #5e98d9; }
+.rarity-label-legendary { color: #ffae00; }
+
+@media (max-width: 768px) {
+    .top-bar {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: flex-start;
+    }
+
+    .balance-panel {
+        align-self: stretch;
+        justify-content: space-between;
+        width: 100%;
+    }
+
+    .nav-links {
+        width: 100%;
+        justify-content: space-between;
+    }
+
+    main {
+        padding: 1.5rem 5vw 3rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    * {
+        transition: none !important;
+        animation-duration: 0.001ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -204,10 +204,65 @@ main {
     max-width: 460px;
 }
 
+.case-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin: 1.5rem 0 2rem;
+}
+
+.filter-btn {
+    border: 1px solid transparent;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    color: var(--text-muted);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    padding: 0.45rem 1.2rem;
+    cursor: pointer;
+    transition: background var(--transition), color var(--transition), border-color var(--transition), transform var(--transition), box-shadow var(--transition);
+}
+
+.filter-btn:hover {
+    color: var(--text-main);
+    border-color: rgba(255, 255, 255, 0.2);
+    transform: translateY(-1px);
+}
+
+.filter-btn.active {
+    background: linear-gradient(135deg, rgba(255, 180, 0, 0.4), rgba(136, 71, 255, 0.35));
+    color: #120a1f;
+    border-color: rgba(255, 180, 0, 0.45);
+    box-shadow: 0 14px 24px rgba(255, 180, 0, 0.25);
+}
+
 .case-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
     gap: 1.5rem;
+}
+
+.case-grid.empty {
+    grid-template-columns: 1fr;
+    place-items: center;
+}
+
+.case-grid.empty .empty-cases {
+    text-align: center;
+    padding: 2.5rem;
+    border-radius: 1.5rem;
+    background: var(--bg-elevated);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    box-shadow: 0 18px 36px rgba(0, 0, 0, 0.35);
+}
+
+.case-grid.empty .empty-cases h3 {
+    margin-bottom: 0.75rem;
+}
+
+.case-grid.empty .empty-cases p {
+    margin: 0;
+    color: var(--text-muted);
 }
 
 .case-card {
@@ -224,14 +279,33 @@ main {
     gap: 1rem;
 }
 
+.case-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.case-header h3 {
+    margin: 0;
+    font-size: 1.35rem;
+    flex: 1;
+}
+
+.case-category {
+    padding: 0.25rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    white-space: nowrap;
+}
+
 .case-card:hover {
     transform: translateY(-6px);
     box-shadow: 0 22px 38px rgba(0, 0, 0, 0.35);
-}
-
-.case-card h3 {
-    margin: 0;
-    font-size: 1.35rem;
 }
 
 .case-card .case-meta {
@@ -436,6 +510,91 @@ main {
     border: 1px solid rgba(255, 255, 255, 0.1);
     box-shadow: 0 28px 60px rgba(0, 0, 0, 0.45);
     position: relative;
+}
+
+.modal.deposit .modal-content {
+    width: min(420px, 90vw);
+    max-height: none;
+    padding: 2.25rem 2.5rem;
+}
+
+.deposit-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.25rem;
+}
+
+.deposit-header h3 {
+    margin: 0;
+}
+
+.deposit-header p {
+    margin: 0.5rem 0 0;
+    color: var(--text-muted);
+}
+
+.deposit-form {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.deposit-form label {
+    font-weight: 600;
+    font-size: 0.9rem;
+}
+
+.deposit-input-group {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    background: var(--bg-accent);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 1rem;
+    padding: 0.85rem 1.1rem;
+    transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.deposit-input-group span {
+    color: var(--text-muted);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.deposit-input-group input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    color: var(--text-main);
+    font-size: 1.2rem;
+    font-weight: 600;
+    outline: none;
+}
+
+.deposit-input-group input::placeholder {
+    color: rgba(255, 255, 255, 0.3);
+}
+
+.deposit-input-group.has-error {
+    border-color: rgba(231, 76, 60, 0.65);
+    box-shadow: 0 0 0 1px rgba(231, 76, 60, 0.35);
+}
+
+.form-error {
+    min-height: 1.2rem;
+    color: var(--danger);
+    font-size: 0.85rem;
+    margin: -0.25rem 0 0.5rem;
+}
+
+.modal-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.modal-actions .btn {
+    flex: 1;
 }
 
 .modal-close {


### PR DESCRIPTION
## Summary
- add landing page with hero, case catalogue, and inventory management for CS2 skins
- implement detailed modal with roulette animation, balance handling, and weighted drop chances
- style the experience with immersive theme, rarity highlights, and responsive layouts
- switch skin artwork to Steam economy endpoints with fallback handling so images render reliably
- expand the catalogue with additional themed cases (AWP, Desert Eagle, USP, farm variants) and tuned drop tables

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dfbe2ee8388333bee603797b8fcb40