### PR TITLE
Handle failed checkin request

### DIFF
--- a/node.py
+++ b/node.py
@@ -37,7 +37,7 @@ proxy = {
 }
 
 try:
-    r = curl_requests.post(
+    response = curl_requests.post(
         url_checkin,
         headers=headers,
         json=payload,
@@ -45,16 +45,17 @@ try:
         proxies=proxy,
         impersonate="chrome120",
     )
-    print(f"Status /checkin: {r.status_code}")
-    r = r.json()
+    print(f"Status /checkin: {response.status_code}")
+    response_json = response.json()
     print("Полученные данные: ")
-    print(f"IP: {r['destinations'][0]}")
-    print(f"TOKEN: {r['token']}")
+    print(f"IP: {response_json['destinations'][0]}")
+    print(f"TOKEN: {response_json['token']}")
 except Exception as e:
     print(f"Ошибка прохождения /checkin: {e}")
+    raise SystemExit(1)
 
-ip_websockets = r['destinations'][0]
-TOKEN = r['token']
+ip_websockets = response_json['destinations'][0]
+TOKEN = response_json['token']
 
 
 # АСИНХРОННЫЙ ЗАПРОС


### PR DESCRIPTION
## Summary
- exit the script early when the /checkin request fails instead of using an undefined response
- keep the websocket bootstrap logic unchanged while ensuring the script only runs when the response is available

## Testing
- not run (network dependent script)


------
https://chatgpt.com/codex/tasks/task_e_68e8033aedbc8333b02a8a65dca0ef51