### PR TITLE
Fix WebSocket proxy configuration

### DIFF
--- a/node.py
+++ b/node.py
@@ -104,7 +104,7 @@ async def main_websockets_connect():
             # Используем curl_cffi для WebSocket с прокси
             async with WebSocket(
                 url,
-                proxy=proxy_url,  # Указываем прокси здесь
+                http_proxy=proxy_url,  # Указываем прокси здесь в поддерживаемом параметре
                 impersonate="chrome120",  # имитация браузера (опционально, но полезно)
                 timeout=10
             ) as ws:


### PR DESCRIPTION
## Summary
- replace the unsupported `proxy` argument when constructing the WebSocket with the supported `http_proxy` parameter so the connection can run through the configured proxy

## Testing
- python node.py *(fails: ModuleNotFoundError: No module named 'curl_cffi')*
- pip install curl_cffi *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68e8069587b8833384727662217347c3